### PR TITLE
Fix Korean index and language switcher

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -412,8 +412,9 @@ nav {
 }
 // Language switcher (desktop)
 .lang-switcher-item {
+    top: 5px;
     .lang-switcher-toggle {
-        color: $white;
+
         font-size: 0.875rem;
         padding: 0.25rem 0.5rem;
         display: flex;
@@ -437,7 +438,7 @@ nav {
         margin-top: 0.25rem;
 
         .dropdown-item {
-            color: $white;
+            color: $light;
             font-size: 0.875rem;
             padding: 0.4rem 1rem;
             opacity: 1;
@@ -466,7 +467,7 @@ nav {
     margin-top: 1rem;
 
     i {
-        color: white;
+        color: $light;
         margin-right: 0.5rem;
     }
 

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -410,6 +410,89 @@ nav {
         color: white;
     }
 }
+// Language switcher (desktop)
+.lang-switcher-item {
+    .lang-switcher-toggle {
+        color: $white;
+        font-size: 0.875rem;
+        padding: 0.25rem 0.5rem;
+        display: flex;
+        align-items: center;
+        white-space: nowrap;
+
+        &:hover, &:focus {
+            color: rgba($white, 0.75);
+        }
+
+        &::after {
+            margin-left: 0.4em;
+        }
+    }
+
+    .lang-switcher-menu {
+        background-color: $dark;
+        border: 1px solid lighten($dark, 10%);
+        border-radius: 4px;
+        min-width: 8rem;
+        margin-top: 0.25rem;
+
+        .dropdown-item {
+            color: $white;
+            font-size: 0.875rem;
+            padding: 0.4rem 1rem;
+            opacity: 1;
+
+            &:hover, &:focus {
+                background-color: lighten($dark, 8%);
+                color: $bright-green;
+            }
+
+            &.active {
+                background-color: transparent;
+                color: $bright-green;
+                font-weight: $font-weight-bold;
+                pointer-events: none;
+
+                &::before {
+                    content: "✓ ";
+                }
+            }
+        }
+    }
+}
+
+// Language switcher (mobile)
+.mobile-lang-switcher {
+    margin-top: 1rem;
+
+    i {
+        color: white;
+        margin-right: 0.5rem;
+    }
+
+    .mobile-lang-list {
+        margin-top: 0.5rem;
+        padding-left: 1.5rem;
+
+        li a {
+            color: rgba($white, 0.7);
+            font-size: 1rem;
+            text-decoration: none;
+            display: block;
+            padding: 0.25rem 0;
+
+            &:hover, &:focus {
+                color: $bright-green;
+            }
+
+            &.active {
+                color: $bright-green;
+                font-weight: $font-weight-bold;
+            }
+        }
+    }
+}
+
 @media(max-width:991px) {
     .nav-item {
         position: static;

--- a/content/kr/_index.md
+++ b/content/kr/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Labs Practices Site"
+linkTitle: "Labs Practices Site"
+description: "Labs Practices Site"
+tagline: "Do what works. Do the right thing. Be kind."
+indexes:
+  - "practices"
+  - "learningpaths"
+  - "guides"
+featured:
+  - "practices/2x2"
+  - "practices/3-column-retro"
+  - "practices/journey-map"
+  - "practices/boris"
+  - "practices/event-storming"
+  - "practices/molecule-map"
+  - "practices/postmortem"
+  - "practices/stack-ranking"
+  - "practices/draw-toast"
+  - "practices/value-stream-map"
+  - "practices/design-studio"
+  - "practices/team-working-agreements"
+  - "practices/lean-experiments"
+  - "practices/service-blueprint"
+---

--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -1,10 +1,9 @@
-{{/* Link directly to documentation etc., if possible. */}}
-{{ $langPage := cond (gt (len .Translations) 0) . .Site.Home }}
-<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	{{ $langPage.Language.LanguageName }}
+<a class="nav-link dropdown-toggle lang-switcher-toggle" href="#" id="langDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <i class="fas fa-globe mr-1"></i>{{ .Language.LanguageName }}
 </a>
-<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-	{{ range $langPage.Translations }}
-	<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
-	{{ end }}
+<div class="dropdown-menu dropdown-menu-right lang-switcher-menu" aria-labelledby="langDropdown">
+  <a class="dropdown-item active" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+  {{ range .Translations }}
+  <a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+  {{ end }}
 </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -34,6 +34,11 @@
 					</div>
 
 				</li>
+				{{ if gt (len .Translations) 0 }}
+				<li class="nav-item dropdown mb-0 lang-switcher-item">
+					{{ partial "navbar-lang-selector.html" . }}
+				</li>
+				{{ end }}
 				<li id="theme-slider" class="d-flex nav-item ml-lg-2 ml-1 mb-0 position-relative text-nowrap">
 					<div id="theme-icon-circle">
 						<span id="dark-theme-icon"><i class="fas fa-moon"></i></span>
@@ -68,6 +73,18 @@
 				</svg>
 				<a tabindex=-1 href="/search/">Search</a>
 			</li>
+			{{ if gt (len .Translations) 0 }}
+			<li class="mobile-lang-switcher">
+				<i class="fas fa-globe"></i>
+				<span class="mobile-nav-title">Language</span>
+				<ul class="list-unstyled mobile-lang-list">
+					<li><a class="active" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
+					{{ range .Translations }}
+					<li><a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
+					{{ end }}
+				</ul>
+			</li>
+			{{ end }}
 		</ul>
 	</div>
 </nav>


### PR DESCRIPTION
Hey @joemoore！ 久しぶり！ 
Thanks for keeping the lights on at the practices site — I refer to it often 😁

While digging deep in my search results for a miro template last week, I discovered the site has most practices available in Korean. I'd just never noticed, because both the language switcher and the Korean homepage were broken 😅
This is very useful to me right now — I've got a lot of new colleagues who speak Korean as a first language, and (selfishly) I'd love the site to be more ergonomic when I pair with them.

**What's in here**
- `content/kr/_index.md` — adds the missing Korean homepage index (title / tagline / featured practices) so `/kr/` renders instead of falling over.
- `layouts/partials/navbar-lang-selector.html` — reworks the selector to show the current language as active (with a ✓) alongside the available translations.
- `layouts/partials/navbar.html` — wires the selector into both desktop and mobile nav, gated on `.Translations > 0` so it only appears on pages that actually have a translation (monolingual pages won't show an empty switcher).
- `assets/scss/_nav.scss` — styling for the desktop dropdown and the mobile language list.

**How I tested**
Ran `make dev-container.pr-test` then built locally with `make preview` and confirmed the switcher appears on EN and KR pages, the KR homepage renders, and English-only pages show no switcher.

I'm not well versed in Hugo templates, so I tried to match the patterns already in the repo — please let me know if you'd like any revisions 😄 

Wishing you all the best,
Greg